### PR TITLE
Fix DoS vulnerability in restrict_access

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -151,7 +151,7 @@ class UsersController < ApplicationController
         if params[:user]
           # visitor changing his/her own info : restrict fields
           params[:user].keys.each do |k|
-            params[:user].delete(k) unless [:login, :time_zone, :lang, :password, :time_zone, :retype_password, :old_password].include?(k.to_sym)
+            params[:user].delete(k) unless ['login', 'time_zone', 'lang', 'password', 'time_zone', 'retype_password', 'old_password'].include?(k.to_s)
           end
         end
       else


### PR DESCRIPTION
Symbols are not garbage collected, so if `.to_sym` is called on (a subset of) `params`, visitors/users can create unlimited symbols, effectively doing a DoS attack against the server.

This commit fixes the DoS vulnerability by making the `restrict_access` method check against strings instead of symbols.
